### PR TITLE
Add ability to filter notes by tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chrono"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -63,12 +63,12 @@ dependencies = [
 name = "cub"
 version = "0.1.1-alpha.0"
 dependencies = [
- "chrono 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusqlite 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusqlite 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -370,7 +370,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
 "checksum cfg-if 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "efe5c877e17a9c717a0bf3613b2709f723202c4e4675cc8f12926ded29bcb17e"
-"checksum chrono 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6962c635d530328acc53ac6a955e83093fedc91c5809dfac1fa60fa470830a37"
+"checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b957d88f4b6a63b9d70d5f454ac8011819c6efa7727858f458ab71c756ce2d3e"
 "checksum dirs 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "37a76dd8b997af7107d0bb69d43903cf37153a18266f8b3fdb9911f28efb5444"
 "checksum env_logger 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "7873e292d20e8778f951278972596b3df36ac72a65c5b406f6d4961070a870c1"
@@ -391,7 +391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum regex 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5bbbea44c5490a1e84357ff28b7d518b4619a159fed5d25f6c1de2d19cc42814"
 "checksum regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "747ba3b235651f6e2f67dfa8bcdcd073ddb7c243cb21c442fc12395dfcac212d"
-"checksum rusqlite 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d9409d78a5a9646685688266e1833df8f08b71ffcae1b5db6c1bfb5970d8a80f"
+"checksum rusqlite 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c9d9118f1ce84d8d0b67f9779936432fb42bb620cef2122409d786892cce9a3c"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum termcolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "722426c4a0539da2c4ffd9b419d90ad540b4cff4a053be9069c908d4d07e2836"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,12 +5,12 @@ authors = ["Andrew Huynh <a5thuynh@gmail.com>"]
 publish = false
 
 [dependencies]
-chrono = "0.4.4"
+chrono = "0.4.6"
 clap = { version = "2.32.0", features = ["yaml"] }
 env_logger = "0.5.11"
 dirs = "1.0.2"
 log = "0.4.3"
-rusqlite = "0.13.0"
+rusqlite = "0.14.0"
 term = "0.4.6"
 
 [lib]

--- a/src/args.rs
+++ b/src/args.rs
@@ -38,11 +38,26 @@ pub fn parse_limit(matches: &clap::ArgMatches) -> Limit {
     Limit::FINITE(100)
 }
 
+/// Parse tag strings
+pub fn parse_tags(matches: &clap::ArgMatches) -> Vec<String> {
+    let mut tags = Vec::new();
+
+    if matches.is_present("tags") {
+        let matched = matches.values_of("tags").unwrap();
+        for tag in matched {
+            println!("{}", tag);
+            tags.push(String::from(tag))
+        }
+    }
+
+    tags
+}
+
 #[cfg(test)]
 mod tests {
     use clap::App;
     use libcub::note::NoteStatus;
-    use args::{ Limit, parse_filters, parse_limit };
+    use args::{ Limit, parse_filters, parse_limit, parse_tags };
 
     #[test]
     fn test_parse_filters() {
@@ -86,5 +101,20 @@ mod tests {
             Limit::FINITE(val) => assert_eq!(val, 100),
             Limit::INFINITE => {}
         }
+    }
+
+    #[test]
+    fn test_parse_tags() {
+         let yaml = load_yaml!("cli.yml");
+        let app = App::from_yaml(yaml);
+
+        // Testing a valid limit value
+        let matches = app.get_matches_from(vec!["cub", "ls", "-t", "cooking", "-t", "drafts"]);
+        let subcommand = matches.subcommand_matches("ls").unwrap();
+        let tags = parse_tags(subcommand);
+
+        assert_eq!(tags.len(), 2);
+        assert_eq!(tags[0], "cooking");
+        assert_eq!(tags[1], "drafts");
     }
 }

--- a/src/cli.yml
+++ b/src/cli.yml
@@ -31,6 +31,11 @@ subcommands:
             help: Limit the number of notes printed.
             takes_value: true
             conflicts_with: all
+        - tags:
+            short: t
+            help: Filter notes by tag
+            takes_value: true
+            multiple: true
   - show:
       about: Show a single note.
       args:

--- a/src/libcub/mod.rs
+++ b/src/libcub/mod.rs
@@ -17,8 +17,8 @@ const BASE_NOTE_QUERY: &str = "SELECT
         ZSUBTITLE,
         ZTEXT,
         ZLASTEDITINGDEVICE,
-        strftime('%s', ZCREATIONDATE),
-        strftime('%s', ZMODIFICATIONDATE),
+        datetime(ZCREATIONDATE, 'unixepoch', '+31 years'),
+        datetime(ZMODIFICATIONDATE, 'unixepoch', '+31 years'),
         ZARCHIVED,
         ZTRASHED
     FROM ZSFNOTE";
@@ -91,7 +91,7 @@ pub fn list_notes(conn: &Connection, filters: &[NoteStatus], limit: &Limit) -> R
     Ok(notes)
 }
 
-
+/// List all tags
 pub fn list_tags(conn: &Connection) -> Result<Vec<Tag>, &'static str> {
     let mut stmt = conn.prepare(BASE_TAG_QUERY).unwrap();
     let mut tags = Vec::new();

--- a/src/libcub/mod.rs
+++ b/src/libcub/mod.rs
@@ -24,9 +24,11 @@ const BASE_NOTE_QUERY: &str = "SELECT
     FROM ZSFNOTE";
 
 const BASE_TAG_QUERY: &str = "SELECT Z_PK, ZTITLE FROM ZSFNOTETAG ORDER BY ZTITLE";
-const BASE_NOTE_TAG_FILTER: &str = "SELECT
+// Only a partial query, the full query is constructed in `apply_filters`
+const NOTE_TAG_PARTIAL: &str = "SELECT
     Z_6NOTES FROM Z_6TAGS
-    WHERE Z_13TAGS IN";
+    WHERE Z_13TAGS IN
+    (SELECT Z_PK FROM ZSFNOTETAG WHERE ZTITLE IN";
 
 
 /// Detect and connect to the Bear application sqlite database.
@@ -51,11 +53,7 @@ fn apply_filters(query: &str, filters: &[NoteStatus], tags: &[String]) -> String
     }
 
     if !tags.is_empty() {
-        let tag_filter = format!(
-            "Z_PK IN ({} (SELECT Z_PK FROM ZSFNOTETAG WHERE ZTITLE IN (\"{}\")))",
-            BASE_NOTE_TAG_FILTER,
-            tags.join("\",\"")
-        );
+        let tag_filter = format!("Z_PK IN ({} (\"{}\")))", NOTE_TAG_PARTIAL, tags.join("\",\""));
 
         if !filter_sql.is_empty() {
             query_str = format!("{} AND ({})", query_str, tag_filter);

--- a/src/libcub/note.rs
+++ b/src/libcub/note.rs
@@ -20,7 +20,6 @@ impl fmt::Display for NoteStatus {
     }
 }
 
-
 #[derive(Debug)]
 pub struct Note {
     pub pk: i32,
@@ -36,10 +35,10 @@ pub struct Note {
 impl Note {
     pub fn from_sql(row: &Row) -> Note {
         let mut status = NoteStatus::NORMAL;
-        if row.get::<i32, i32>(7) == 1 {
+        if row.get::<usize, i32>(7) == 1 {
             // Is it archived?
             status = NoteStatus::ARCHIVED;
-        } else if row.get::<i32, i32>(8) == 1 {
+        } else if row.get::<usize, i32>(8) == 1 {
             // Is it trashed?
             status = NoteStatus::TRASHED;
         }
@@ -50,17 +49,31 @@ impl Note {
             subtitle: row.get(2),
             text: row.get(3),
             last_editing_device: row.get(4),
-            creation_date: NaiveDateTime::from_timestamp(
-                row.get_checked(5).unwrap_or(0),
-                0
-            ),
-            modification_date: NaiveDateTime::from_timestamp(
-                row.get_checked(6).unwrap_or(0),
-                0
-            ),
+            creation_date: NaiveDateTime::parse_from_str(
+                row.get::<usize, String>(5).as_str(),
+                "%Y-%m-%d %H:%M:%S"
+            ).unwrap(),
+            modification_date: NaiveDateTime::parse_from_str(
+                row.get::<usize, String>(6).as_str(),
+                "%Y-%m-%d %H:%M:%S"
+            ).unwrap(),
             status
         }
     }
+}
+
+impl fmt::Display for Note {
+    fn fmt(&self, f:&mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{:-4} {} {} {}",
+            self.pk,
+            self.status,
+            self.modification_date,
+            self.title
+        )
+    }
+
 }
 
 pub struct Tag {

--- a/src/libcub/note.rs
+++ b/src/libcub/note.rs
@@ -1,6 +1,7 @@
 extern crate chrono;
 use chrono::prelude::*;
 use rusqlite::{ Row };
+use std::fmt;
 
 #[derive(Debug, PartialEq)]
 pub enum NoteStatus {
@@ -8,6 +9,17 @@ pub enum NoteStatus {
     TRASHED,
     NORMAL
 }
+
+impl fmt::Display for NoteStatus {
+    fn fmt(&self, f:&mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            NoteStatus::ARCHIVED => write!(f, "A"),
+            NoteStatus::TRASHED => write!(f, "T"),
+            NoteStatus::NORMAL => write!(f, "."),
+        }
+    }
+}
+
 
 #[derive(Debug)]
 pub struct Note {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod args;
 use args::{
     parse_filters,
     parse_limit,
+    parse_tags,
 };
 
 extern crate libcub;
@@ -54,8 +55,9 @@ fn main() {
 
         let filters = parse_filters(matches);
         let limit = parse_limit(matches);
+        let tags = parse_tags(matches);
 
-        for note in list_notes(&conn, &filters, &limit).unwrap() {
+        for note in list_notes(&conn, &filters, &tags, &limit).unwrap() {
             // Color the notes depending on the note status
             if matches.is_present("color") {
                 match note.status {

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn main() {
                 }
             }
 
-            writeln!(t, "{:-4} {}", note.pk, note.title).unwrap();
+            writeln!(t, "{}", note).unwrap();
             if matches.is_present("full") {
                 writeln!(t, "{}", note.subtitle).unwrap();
             }


### PR DESCRIPTION
- Add modification time & note status to `ls`
- Fixed broken timestamp parsing. Since Bear uses CoreData, timestamps are actually rooted on January 1, 2001 instead of the typical unix epoch timestamps.
- Closes #1 